### PR TITLE
Swoodford clear patch 1

### DIFF
--- a/awsssoprofiletool.sh
+++ b/awsssoprofiletool.sh
@@ -207,9 +207,7 @@ do
 	    if [ -z "$output" ]; then output=$defoutput ; fi
 	    defoutput=$output
 	fi
-	# This sets the profile name in the cli
 	p="$rolename-$acctnum"
-	# p="$(echo $profilename | tr '[:upper:]' '[:lower:]')"
 
 	while true ; do
 	    if $interactive ;
@@ -243,8 +241,9 @@ do
 	done
 	echo -n "Creating $profilename... "
 	echo "" >> "$profilefile"
+ 	# The below sets the profile name in the cli
 	# echo "[profile $profilename]" >> "$profilefile"
-	# Use acctname for profile name, convert to lowercase
+	# Use acctname for profile name, convert spaces to dash and all to lowercase
 	echo "[profile $(echo $acctname | tr ' ' '-' | tr '[:upper:]' '[:lower:]')]" >> "$profilefile"
 	echo "sso_start_url = $2" >> "$profilefile"
 	echo "sso_region = $1" >> "$profilefile"

--- a/awsssoprofiletool.sh
+++ b/awsssoprofiletool.sh
@@ -29,7 +29,7 @@
 
 ACCOUNTPAGESIZE=10
 ROLEPAGESIZE=10
-PROFILEFILE="$HOME/.aws/config"
+PROFILEFILE="$HOME/.aws/awsssoprofiletool"
 
 if [ $# -lt 2 ];
 then
@@ -91,6 +91,7 @@ echo
 echo "$regurl"
 echo
 echo "Press <ENTER> after you have signed in to continue..."
+open "$regurl"
 
 read continue
 
@@ -206,8 +207,10 @@ do
 	    if [ -z "$output" ]; then output=$defoutput ; fi
 	    defoutput=$output
 	fi
-	
+	# This sets the profile name in the cli
 	p="$rolename-$acctnum"
+	# p="$(echo $profilename | tr '[:upper:]' '[:lower:]')"
+
 	while true ; do
 	    if $interactive ;
 	    then
@@ -240,7 +243,9 @@ do
 	done
 	echo -n "Creating $profilename... "
 	echo "" >> "$profilefile"
-	echo "[profile $profilename]" >> "$profilefile"
+	# echo "[profile $profilename]" >> "$profilefile"
+	# Use acctname for profile name, convert to lowercase
+	echo "[profile $(echo $acctname | tr ' ' '-' | tr '[:upper:]' '[:lower:]')]" >> "$profilefile"
 	echo "sso_start_url = $2" >> "$profilefile"
 	echo "sso_region = $1" >> "$profilefile"
 	echo "sso_account_id = $acctnum" >> "$profilefile"


### PR DESCRIPTION
1. Don't add or overwrite to the default config, instead make a new file called awsssoprofiletool
2. Open the browser window automatically instead of copying and pasting url
3. Use the account name for the cli profile instead of role name and account number